### PR TITLE
Include ability to add a specified user to the monitoring list on post

### DIFF
--- a/CommentBot.php
+++ b/CommentBot.php
@@ -7,7 +7,7 @@ class CommentBotPlugin extends MantisPlugin {
 		$this->description = "Automated bugticket commenting hook";
 		$this->page = 'config';
 
-		$this->version = '1.1';
+		$this->version = '1.2';
 		$this->requires = array(
 			'MantisCore' => '1.2.0',
 		);
@@ -29,6 +29,7 @@ class CommentBotPlugin extends MantisPlugin {
 		return array(
 			'username' => '',
 			'secret_key' => "",
+			'add_to_monitoring' => False,
 			'send_mail' => False,
 			'log_history' => False
 		);

--- a/pages/config.php
+++ b/pages/config.php
@@ -2,6 +2,7 @@
 auth_reauthenticate();
 access_ensure_global_level(config_get('manage_plugin_threshold'));
 
+$conf_add_to_monitoring = plugin_config_get("add_to_monitoring");
 $conf_log_history = plugin_config_get("log_history");
 $conf_send_mail = plugin_config_get("send_mail");
 
@@ -32,6 +33,13 @@ print_manage_menu();
 	<td class="category">Access URL</td>
 	<td class="center">
 		 <?php echo ($_SERVER['HTTPS'] ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'] . $_SERVER['PHP_SELF'] . "?page=CommentBot/post" ?>
+	</td>
+</tr>
+
+<tr <?php echo helper_alternate_class() ?>>
+	<td class="category">Add specified user to monitoring</td>
+	<td class="center">
+		<input type="checkbox" name="add_to_monitoring" <?php check_checked($conf_add_to_monitoring, TRUE) ?> />
 	</td>
 </tr>
 

--- a/pages/config_edit.php
+++ b/pages/config_edit.php
@@ -6,6 +6,7 @@ access_ensure_global_level( config_get( 'manage_plugin_threshold' ) );
 
 $f_username = gpc_get_string('username', '');
 $f_secret_key = gpc_get_string('secret_key', '');
+$f_add_to_monitoring = gpc_get_bool('add_to_monitoring', FALSE);
 $f_log_history = gpc_get_bool('log_history', FALSE);
 $f_send_mail = gpc_get_bool('send_mail', FALSE);
 
@@ -21,6 +22,7 @@ if (plugin_config_get('secret_key') != $f_secret_key) {
 	plugin_config_set('secret_key', $f_secret_key);
 }
 
+plugin_config_set('add_to_monitoring', $f_add_to_monitoring);
 plugin_config_set('log_history', $f_log_history);
 plugin_config_set('send_mail', $f_send_mail);
 

--- a/pages/post.php
+++ b/pages/post.php
@@ -6,16 +6,25 @@ require_once('user_api.php');
 
 $user_id = user_get_id_by_name(plugin_config_get('username'));
 $secret_key = plugin_config_get('secret_key');
+$add_to_monitoring = plugin_config_get('add_to_monitoring');
 $send_mail = plugin_config_get('send_mail');
 $log_history = plugin_config_get('log_history');
 
 $f_bug_id = gpc_get_int('bug_id');
 $f_secret_key = gpc_get_string('secret_key');
+$f_monitor = gpc_get_string('monitor');
 $f_message = gpc_get_string('message');
+
+$t_user_id = user_get_id_by_email( $f_monitor );
 
 if ($secret_key == $f_secret_key) {
 	$t_bug = bug_get($f_bug_id, true);
 	if ($t_bug) {
+		if ($add_to_monitoring && $t_user_id) {
+			bug_monitor($f_bug_id, $t_user_id);
+			sleep(1);
+		}
+
 		bugnote_add($f_bug_id, $f_message, '0:00', false, BUGNOTE, '', $user_id, $send_mail, $log_history);
 	}
 }

--- a/pages/post.php
+++ b/pages/post.php
@@ -1,5 +1,6 @@
 <?php
 require_once('core.php');
+require_once('authentication_api.php');
 require_once('bug_api.php');
 require_once('bugnote_api.php');
 require_once('user_api.php');
@@ -19,7 +20,13 @@ $t_user_id = user_get_id_by_email( $f_monitor );
 
 if ($secret_key == $f_secret_key) {
 	$t_bug = bug_get($f_bug_id, true);
+
 	if ($t_bug) {
+		// Mantis will abort after adding the bug note (but before updating history or sending an e-mail)
+		// if the script is not authenticated like this.
+		auth_attempt_script_login(plugin_config_get('username'));
+
+		// Add the specified user to the monitoring list, if applicable
 		if ($add_to_monitoring && $t_user_id) {
 			bug_monitor($f_bug_id, $t_user_id);
 			sleep(1);


### PR DESCRIPTION
Ideally it should be possible for a user (for example, the author of a commit) to receive an e-mail when CommentBot has added a comment to the ticket, even if they are not actually monitoring the ticket. This provides certainty to the user that the ticket was in fact updated.

The pull request adds this functionality.
